### PR TITLE
fix: nama paket mikey179/vfsstream menjadi lowercase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"paragonie/random_compat": "Provides better randomness in PHP 5.x"
 	},
 	"require-dev": {
-		"mikey179/vfsStream": "1.1.*",
+		"mikey179/vfsstream": "1.1.*",
 		"phpunit/phpunit": "4.* || 5.*"
 	}
 }


### PR DESCRIPTION
Saya coba jalankan `composer install` error. Harus lowercase

![ss-2025-04-25-12:45:13](https://github.com/user-attachments/assets/8ecbad9a-35a1-429b-a9ac-0e051712ec55)
